### PR TITLE
fix(prompt): split p6_return_words word and variable into separate args

### DIFF
--- a/init.zsh
+++ b/init.zsh
@@ -39,5 +39,6 @@ p6df::modules::cucumber::vscodes() {
 ######################################################################
 p6df::modules::cucumber::profile::mod() {
 
+  # shellcheck disable=SC2016
   p6_return_words 'cucumber' '$DEBUG'
 }

--- a/init.zsh
+++ b/init.zsh
@@ -29,22 +29,15 @@ p6df::modules::cucumber::vscodes() {
 ######################################################################
 #<
 #
-# Function: str str = p6df::modules::cucumber::prompt::mod()
+# Function: words cucumber $DEBUG = p6df::modules::cucumber::profile::mod()
 #
 #  Returns:
-#	str - str
+#	words - cucumber $DEBUG
 #
 #  Environment:	 DEBUG
 #>
 ######################################################################
-p6df::modules::cucumber::prompt::mod() {
+p6df::modules::cucumber::profile::mod() {
 
-  local str
-
-  if p6_string_blank_NOT "$DEBUG"; then
-    str="cucumber:\t  DEBUG=$DEBUG"
-  fi
-
-  p6_return_str "$str"
+  p6_return_words 'cucumber' '$DEBUG'
 }
-

--- a/init.zsh
+++ b/init.zsh
@@ -40,5 +40,5 @@ p6df::modules::cucumber::vscodes() {
 p6df::modules::cucumber::profile::mod() {
 
   # shellcheck disable=SC2016
-  p6_return_words 'cucumber' '$DEBUG'
+  p6_return_words 'cucumber' "$DEBUG"
 }


### PR DESCRIPTION
## What
Replaces `prompt::mod` with `profile::mod` using `p6_return_words 'cucumber' '$DEBUG'` to split the label word and variable reference into separate args.

## Why
`p6_return_words` expects each token as a distinct argument. The old implementation used `p6_return_str` with an inline interpolated string, which does not work with the new prompt dispatch model.

## Test plan
- Source the module and verify `p6df::modules::cucumber::profile::mod` is defined and callable
- Confirm prompt output format is correct when `$DEBUG` is set

## Dependencies
None