### PR TITLE
fix(cucumber): use single-quoted variables in profile::mod (deferred eval)

### DIFF
--- a/init.zsh
+++ b/init.zsh
@@ -40,5 +40,5 @@ p6df::modules::cucumber::vscodes() {
 p6df::modules::cucumber::profile::mod() {
 
   # shellcheck disable=SC2016
-  p6_return_words 'cucumber' "$DEBUG"
+  p6_return_words 'cucumber' '$DEBUG'
 }


### PR DESCRIPTION
**What:** Restore single-quoted variables in profile::mod p6_return_words calls

**Why:** Variables are intentionally single-quoted; eval happens later via p6_return_words machinery. The SC2016 fix incorrectly expanded them at call time.

**Test plan:** Build CI passes

**Dependencies:** None