### PR TITLE
chore(docs): fix profile::mod return signature and rename in README and init.zsh

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ TODO: Add a short summary of this module.
 
 - `p6df::modules::cucumber::deps()`
 - `p6df::modules::cucumber::vscodes()`
-- `str str = p6df::modules::cucumber::prompt::mod()`
+- `words cucumber = p6df::modules::cucumber::profile::mod()`
 
 ## Hierarchy
 

--- a/init.zsh
+++ b/init.zsh
@@ -29,10 +29,10 @@ p6df::modules::cucumber::vscodes() {
 ######################################################################
 #<
 #
-# Function: words cucumber $DEBUG = p6df::modules::cucumber::profile::mod()
+# Function: words cucumber = p6df::modules::cucumber::profile::mod()
 #
 #  Returns:
-#	words - cucumber $DEBUG
+#	words - cucumber
 #
 #  Environment:	 DEBUG
 #>


### PR DESCRIPTION
**What:** Update README to use profile::mod (was prompt::mod) and remove env var from return signature docs.

**Why:** Keep docs in sync with actual function naming and behavior after recent refactor.

**Test plan:** Reviewed diff manually; changes are documentation and comment-block only.

**Dependencies:** none